### PR TITLE
Allow GHC-8.6.2 bundled boot lib versions

### DIFF
--- a/tz.cabal
+++ b/tz.cabal
@@ -52,7 +52,7 @@ Library
     base               >= 4        && < 5,
     binary             >= 0.5      && < 0.9,
     bytestring         >= 0.9      && < 0.11,
-    containers         >= 0.5      && < 0.6,
+    containers         >= 0.5      && < 0.7,
     data-default       >= 0.5      && < 0.8,
     deepseq            >= 1.1      && < 2,
     time               >= 1.2      && < 1.9,
@@ -63,7 +63,7 @@ Library
       Data.Time.Zones.TH,
       Data.Time.Zones.Internal.CoerceTH
     Build-Depends:
-      template-haskell   >= 2.6      && < 2.14
+      template-haskell   >= 2.6      && < 2.15
     CPP-Options: -DTZ_TH
 
 


### PR DESCRIPTION
`tzdata` needs `containers <0.7` relaxation as well.