### PR TITLE
Build with GHC 8.10

### DIFF
--- a/tz.cabal
+++ b/tz.cabal
@@ -63,7 +63,7 @@ Library
       Data.Time.Zones.TH,
       Data.Time.Zones.Internal.CoerceTH
     Build-Depends:
-      template-haskell   >= 2.6      && < 2.16
+      template-haskell   >= 2.6      && < 2.17
     CPP-Options: -DTZ_TH
 
 


### PR DESCRIPTION
Unfortunately, due to https://github.com/finnsson/template-helper/issues/12, we have to depend on a fork of language-haskell-extract to run the test so far.