### PR TITLE
Allow bytestring v0.11

### DIFF
--- a/Data/Time/Zones.hs
+++ b/Data/Time/Zones.hs
@@ -2,7 +2,7 @@
 Module      : Data.Time.Zones
 Copyright   : (C) 2014 Mihaly Barasz
 License     : Apache-2.0, see LICENSE
-Maintainer  : Mihaly Barasz <klao@nilcons.com>
+Maintainer  : Janus Troelsen <ysangkok@gmail.com>
 Stability   : experimental
 -}
 

--- a/Data/Time/Zones/All.hs
+++ b/Data/Time/Zones/All.hs
@@ -2,7 +2,7 @@
 Module      : Data.Time.Zones.All
 Copyright   : (C) 2014 Mihaly Barasz
 License     : Apache-2.0, see LICENSE
-Maintainer  : Mihaly Barasz <klao@nilcons.com>
+Maintainer  : Janus Troelsen <ysangkok@gmail.com>
 Stability   : experimental
 -}
 

--- a/Data/Time/Zones/Internal.hs
+++ b/Data/Time/Zones/Internal.hs
@@ -2,7 +2,7 @@
 Module      : Data.Time.Zones.Internal
 Copyright   : (C) 2014 Mihaly Barasz
 License     : Apache-2.0, see LICENSE
-Maintainer  : Mihaly Barasz <klao@nilcons.com>
+Maintainer  : Janus Troelsen <ysangkok@gmail.com>
 Stability   : experimental
 -}
 

--- a/Data/Time/Zones/Internal/CoerceTH.hs
+++ b/Data/Time/Zones/Internal/CoerceTH.hs
@@ -2,7 +2,7 @@
 Module      : Data.Time.Zones.Internal.CoerceTH
 Copyright   : (C) 2014 Mihaly Barasz
 License     : Apache-2.0, see LICENSE
-Maintainer  : Mihaly Barasz <klao@nilcons.com>
+Maintainer  : Janus Troelsen <ysangkok@gmail.com>
 Stability   : experimental
 -}
 

--- a/Data/Time/Zones/Internal/CoerceTH.hs
+++ b/Data/Time/Zones/Internal/CoerceTH.hs
@@ -31,6 +31,14 @@ getNewTypeCon newTy = do
 constructNewType :: Name -> Q Exp
 constructNewType newTy = ConE `fmap` getNewTypeCon newTy
 
+mkConP :: Name -> [Pat] -> Pat
+mkConP name pats =
+#if MIN_VERSION_template_haskell(2,18,0)
+  ConP name [] pats
+#else
+  ConP name pats
+#endif
+
 destructNewType :: Name -> Q Exp
 destructNewType newTy = do
   con <- getNewTypeCon newTy
@@ -39,4 +47,4 @@ destructNewType newTy = do
   return $
     LamE [VarP lamV]
     (CaseE (VarE lamV) [
-        Match (ConP con [VarP patV]) (NormalB (VarE patV)) []])
+        Match (mkConP con [VarP patV]) (NormalB (VarE patV)) []])

--- a/Data/Time/Zones/Read.hs
+++ b/Data/Time/Zones/Read.hs
@@ -2,7 +2,7 @@
 Module      : Data.Time.Zones.Read
 Copyright   : (C) 2014 Mihaly Barasz
 License     : Apache-2.0, see LICENSE
-Maintainer  : Mihaly Barasz <klao@nilcons.com>
+Maintainer  : Janus Troelsen <ysangkok@gmail.com>
 Stability   : experimental
 -}
 

--- a/Data/Time/Zones/TH.hs
+++ b/Data/Time/Zones/TH.hs
@@ -2,7 +2,7 @@
 -- Module      : Data.Time.Zones.TH
 -- Copyright   : (C) 2014 Mihaly Barasz
 -- License     : Apache-2.0, see LICENSE
--- Maintainer  : Mihaly Barasz <klao@nilcons.com>
+-- Maintainer  : Janus Troelsen <ysangkok@gmail.com>
 -- Stability   : experimental
 --
 -- /Example usage:/

--- a/Data/Time/Zones/Types.hs
+++ b/Data/Time/Zones/Types.hs
@@ -2,7 +2,7 @@
 Module      : Data.Time.Zones.Types
 Copyright   : (C) 2014 Mihaly Barasz
 License     : Apache-2.0, see LICENSE
-Maintainer  : Mihaly Barasz <klao@nilcons.com>
+Maintainer  : Janus Troelsen <ysangkok@gmail.com>
 Stability   : experimental
 -}
 

--- a/tests/testAll.hs
+++ b/tests/testAll.hs
@@ -3,9 +3,8 @@
 
 import Data.Time.Zones
 import Data.Time.Zones.All
-import Test.Framework.Providers.HUnit
-import Test.Framework.TH
-import Test.HUnit hiding (Test, assert)
+import Test.Tasty.HUnit
+import Test.Tasty.TH
 
 case_Budapest_is_Budapest :: IO ()
 case_Budapest_is_Budapest = do

--- a/tests/testTH.hs
+++ b/tests/testTH.hs
@@ -2,9 +2,8 @@
 
 import Data.Time.Zones
 import Data.Time.Zones.TH
-import Test.Framework.Providers.HUnit
-import Test.Framework.TH
-import Test.HUnit hiding (Test, assert)
+import Test.Tasty.HUnit
+import Test.Tasty.TH
 
 tzBudapest :: TZ
 tzBudapest = $(includeTZFromDB "Europe/Budapest")

--- a/tests/testTZ.hs
+++ b/tests/testTZ.hs
@@ -5,9 +5,8 @@ module Main (main) where
 
 import Data.Time
 import Data.Time.Zones
-import Test.Framework.Providers.HUnit
-import Test.Framework.TH
-import Test.HUnit hiding (Test, assert)
+import Test.Tasty.TH
+import Test.Tasty.HUnit
 
 case_utcTZ_is_utc = timeZoneForPOSIX utcTZ 0 @?= utc
 

--- a/tests/testTZSys.hs
+++ b/tests/testTZSys.hs
@@ -12,10 +12,9 @@ import Data.Time.Zones
 import Data.Time.Zones.Read (pathForSystemTZ)
 import System.Environment
 import System.IO.Unsafe
-import Test.Framework.Providers.QuickCheck2
-import Test.Framework.TH
-import Test.HUnit hiding (Test, assert)
-import Test.QuickCheck
+import Test.Tasty.HUnit
+import Test.Tasty.TH
+import Test.Tasty.QuickCheck
 import Test.QuickCheck.Monadic
 
 foreign import ccall safe "time.h tzset" c_tzset :: IO ()

--- a/tz.cabal
+++ b/tz.cabal
@@ -1,5 +1,5 @@
 Name: tz
-Version: 0.1.3.5
+Version: 0.1.3.6
 License: Apache-2.0
 License-File: LICENSE
 Author: Mihaly Barasz, Gergely Risko

--- a/tz.cabal
+++ b/tz.cabal
@@ -63,7 +63,7 @@ Library
       Data.Time.Zones.TH,
       Data.Time.Zones.Internal.CoerceTH
     Build-Depends:
-      template-haskell   >= 2.6      && < 2.17
+      template-haskell   >= 2.6      && < 2.19
     CPP-Options: -DTZ_TH
 
 

--- a/tz.cabal
+++ b/tz.cabal
@@ -77,9 +77,9 @@ Test-Suite tests
     tz,
     base                       >= 4       && < 5,
     HUnit                      >= 1.2     && < 1.7,
-    test-framework             >= 0.4     && < 1,
-    test-framework-hunit       >= 0.2     && < 0.4,
-    test-framework-th          >= 0.2     && < 0.4,
+    tasty,
+    tasty-hunit,
+    tasty-th,
     time                       >= 1.2     && < 1.10
 
 Test-Suite testsSys
@@ -95,9 +95,10 @@ Test-Suite testsSys
     base                       >= 4       && < 5,
     HUnit                      >= 1.2     && < 1.7,
     QuickCheck                 >= 2.4     && < 3,
-    test-framework             >= 0.4     && < 1,
-    test-framework-quickcheck2 >= 0.2     && < 0.4,
-    test-framework-th          >= 0.2     && < 0.4,
+    tasty,
+    tasty-hunit,
+    tasty-th,
+    tasty-quickcheck,
     time                       >= 1.2     && < 1.10
 
 Test-Suite th-test
@@ -112,9 +113,9 @@ Test-Suite th-test
     tz,
     base                       >= 4       && < 5,
     HUnit                      >= 1.2     && < 1.7,
-    test-framework             >= 0.4     && < 1,
-    test-framework-hunit       >= 0.2     && < 0.4,
-    test-framework-th          >= 0.2     && < 0.4
+    tasty,
+    tasty-hunit,
+    tasty-th
 
 Test-Suite test-all
   Default-Language: Haskell2010
@@ -127,9 +128,9 @@ Test-Suite test-all
     tzdata,
     base                       >= 4       && < 5,
     HUnit                      >= 1.2     && < 1.7,
-    test-framework             >= 0.4     && < 1,
-    test-framework-hunit       >= 0.2     && < 0.4,
-    test-framework-th          >= 0.2     && < 0.4
+    tasty,
+    tasty-hunit,
+    tasty-th
 
 Benchmark bench
   Default-Language: Haskell2010

--- a/tz.cabal
+++ b/tz.cabal
@@ -51,7 +51,7 @@ Library
   Build-Depends:
     base               >= 4        && < 5,
     binary             >= 0.5      && < 0.11,
-    bytestring         >= 0.9      && < 0.11,
+    bytestring         >= 0.9      && < 0.12,
     containers         >= 0.5      && < 0.7,
     data-default       >= 0.5      && < 0.8,
     deepseq            >= 1.1      && < 2,

--- a/tz.cabal
+++ b/tz.cabal
@@ -55,7 +55,7 @@ Library
     containers         >= 0.5      && < 0.7,
     data-default       >= 0.5      && < 0.8,
     deepseq            >= 1.1      && < 2,
-    time               >= 1.2      && < 1.10,
+    time               >= 1.2      && < 1.14,
     tzdata             >= 0.1      && < 0.3,
     vector             >= 0.9      && < 0.13
   if flag(template-haskell)
@@ -80,7 +80,7 @@ Test-Suite tests
     tasty,
     tasty-hunit,
     tasty-th,
-    time                       >= 1.2     && < 1.10
+    time                       >= 1.2     && < 1.14
 
 Test-Suite testsSys
   Default-Language: Haskell2010
@@ -99,7 +99,7 @@ Test-Suite testsSys
     tasty-hunit,
     tasty-th,
     tasty-quickcheck,
-    time                       >= 1.2     && < 1.10
+    time                       >= 1.2     && < 1.14
 
 Test-Suite th-test
   Default-Language: Haskell2010
@@ -142,7 +142,7 @@ Benchmark bench
     tz,
     base                       >= 4       && < 5,
     criterion                  >= 0.8     && < 1.6,
-    time                       >= 1.2     && < 1.10,
+    time                       >= 1.2     && < 1.14,
     timezone-olson,
     timezone-series
 

--- a/tz.cabal
+++ b/tz.cabal
@@ -3,13 +3,13 @@ Version: 0.1.3.5
 License: Apache-2.0
 License-File: LICENSE
 Author: Mihaly Barasz, Gergely Risko
-Maintainer: Mihaly Barasz <klao@nilcons.com>, Gergely Risko <errge@nilcons.com>
+Maintainer: Janus Troelsen <ysangkok@gmail.com>
 Cabal-Version: >= 1.10
 Build-Type: Simple
 Category: Data
 Stability: experimental
-Homepage: https://github.com/nilcons/haskell-tz
-Bug-Reports: https://github.com/nilcons/haskell-tz/issues
+Homepage: https://github.com/ysangkok/haskell-tz
+Bug-Reports: https://github.com/ysangkok/haskell-tz/issues
 Synopsis: Efficient time zone handling
 Description:
   The goal of this package is to provide a library that can read time
@@ -31,7 +31,7 @@ Extra-Source-Files:
 
 Source-Repository head
   Type: git
-  Location: https://github.com/nilcons/haskell-tz.git
+  Location: https://github.com/ysangkok/haskell-tz.git
 
 Flag template-haskell
   Description: Enable the use of and export Template Haskell


### PR DESCRIPTION
Stackage will require bytestring 0.11 compatibilty for inclusion, see
https://github.com/commercialhaskell/stackage/pull/6318/files

I have tested this in use, and it seems to work fine.

If you don't want to do a new release, even a revision would be nice, then this
could be more easily used. (without tricks like `--allow-newer` or forked versions)

Thank you for the library.
